### PR TITLE
Fix for CVE-2025-67746

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "php": "^8.1"
     },
     "require-dev": {
-        "composer/composer": "2.8.9",
+        "composer/composer": "^2.9.3",
         "henzeb/enumhancer-ide-helper": "main-dev",
         "mockery/mockery": "^1.5",
         "orchestra/testbench": "^8|^9|^10",


### PR DESCRIPTION
## Summary
[CVE-2025-67746](https://www.cve.org/CVERecord?id=CVE-2025-67746) has a minimum requirement for composer 2.9.3 to be fixed. 
This updates the enumhancer requirements to be at least that. This should prevent issues.

## Details
As part of updating our application we had a security alert via snyk that composer was outdated and possibly issue - it mentioned that the problem was introduced via `henzeb/enumhancer@3.2.0`  - investigating this should be an simple update - with a minor change to the composer.json.



<img width="2894" height="960" alt="image" src="https://github.com/user-attachments/assets/ce8e3619-ce19-4f51-a2ac-ab6cb46b4e83" />
<img width="1934" height="1796" alt="image" src="https://github.com/user-attachments/assets/1fd45d75-336b-4de5-bc34-81e6133bd869" />
